### PR TITLE
fixed initial save error #8

### DIFF
--- a/config.properties
+++ b/config.properties
@@ -1,6 +1,6 @@
 db.url = jdbc:mariadb://localhost:3306/realeditor
 db.username = root
-db.password = 4154
+db.password = maria123
 db.type = dal.MariaDBDAOFactory
 
 #db.url = jdbc:mariadb://localhost:3306/fakerealeditor


### PR DESCRIPTION
fixes #8 
Update config.properties DB password and harden TF-IDF/PMI handling in EditorDBDAO:

- Default NaN TF-IDF values to 0.0 before database updates (two locations) to avoid inserting NaN.
- Compute PMI scores via performPMI(content) and batch-insert PMI values (null/NaN values coerced to 0.0) instead of the previous pos-tag loop.
- Minor rework around batch statements to store PMI per page.

This prevents NaN values from reaching the DB and adds PMI score persistence for pages. (DB password changed in config.properties.)